### PR TITLE
UnicodeSafePynLiner has been moved to sentry.utils.email.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,12 +2,12 @@ from setuptools import find_packages
 from setuptools import setup
 
 install_requires = [
-    'sentry>=6.0.0',
+    'sentry>=6.4.3',
 ]
 
 setup(
     name='sentry-subscriptions',
-    version='0.2.0',
+    version='0.2.1',
     author='John Lynn',
     author_email='jlynn@hearsaycorp.com',
     package_dir={'': 'src'},

--- a/src/sentry_subscriptions/plugin.py
+++ b/src/sentry_subscriptions/plugin.py
@@ -7,7 +7,7 @@ from django.template.loader import render_to_string
 from django.utils.translation import ugettext_lazy as _
 from django.conf import settings
 from sentry.plugins import Plugin
-from sentry.plugins.sentry_mail.models import UnicodeSafePynliner
+from sentry.utils.email import UnicodeSafePynliner
 from sentry.utils.http import absolute_uri
 
 import fnmatch


### PR DESCRIPTION
Sentry v6.4.3 has a new MessageBuilder we should also consider using.
